### PR TITLE
:hammer: ref[#4] 로그아웃 api 코드 수정, SecurityConfig permitAll에 엔드포인트 추가

### DIFF
--- a/src/main/java/com/ohnew/ohnew/common/security/SecurityConfig.java
+++ b/src/main/java/com/ohnew/ohnew/common/security/SecurityConfig.java
@@ -51,8 +51,10 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "login/page",
                                 "/kakao/callback",
+                                "/api/users/kakao-login",
                                 "/api/users/local/signup",
-                                "/api/users/local/login"
+                                "/api/users/local/login",
+                                "/api/users/refresh"
                         ).permitAll()
 
                         // 정적 리소스 (이미지, CSS, JS, webjars 등)

--- a/src/main/java/com/ohnew/ohnew/controller/UserController.java
+++ b/src/main/java/com/ohnew/ohnew/controller/UserController.java
@@ -41,8 +41,8 @@ public class UserController {
 
     @Operation(summary = "로그아웃(앱)", description = "액세스 토큰을 무효화하여 로그아웃")
     @PostMapping("/logout")
-    public ApiResponse<SuccessStatus> logout(
-            @RequestHeader(value = "Authorization", required = false) String accessToken) {
+    public ApiResponse<SuccessStatus> logout(){
+        String accessToken = jwtTokenProvider.resolveAccessToken();
 
         userService.logout(accessToken);
         return ApiResponse.onSuccess(SuccessStatus._OK);


### PR DESCRIPTION
## 🔍 이슈 번호
[#4]
## ✨ PR 요약
<!--변경 포인트-->
- 로그아웃 API 다른 API와 스타일 통일
- SecurityConfig permitAll에 토큰 재발급 api, 앱 카카오로그인 엔드포인트 추가
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Kakao login without prior authentication, simplifying third‑party sign-in for new and returning users.
  * Enabled token refresh without an active session, allowing clients to renew access more reliably.

* **Improvements**
  * Simplified logout flow: no need to provide an Authorization header; the token is detected automatically, reducing client-side handling and potential header-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->