### PR TITLE
:hammer: REF [#19] 3스타일 요약 도입, Q&A는 부모 News 저장, batch3 연동

### DIFF
--- a/src/main/java/com/ohnew/ohnew/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ohnew/ohnew/apiPayload/code/status/ErrorStatus.java
@@ -44,6 +44,8 @@ public enum ErrorStatus implements BaseErrorCode {
     RSS_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NEWS5001", "RSS 데이터를 가져오는데 실패했습니다."),
     AI_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NEWS5002", "AI 처리 중 오류가 발생했습니다."),
 
+    VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "VARIANT4040", "요약 변형을 찾을 수 없습니다."),
+
     //챗봇 관련 에러
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404", "채팅방이 존재하지 않습니다.");
 

--- a/src/main/java/com/ohnew/ohnew/common/security/SecurityConfig.java
+++ b/src/main/java/com/ohnew/ohnew/common/security/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                                 "/swagger-resources/**"
                         ).permitAll()
 
-                        // AWS 헬스 체크
+                        // 헬스 체크
                         .requestMatchers("/health").permitAll()
 
                         //카카오/로컬/로그인

--- a/src/main/java/com/ohnew/ohnew/controller/ChatController.java
+++ b/src/main/java/com/ohnew/ohnew/controller/ChatController.java
@@ -40,8 +40,8 @@ public class ChatController {
 
     @Operation(summary = "특정 기사로 챗봇이랑 대화하기", description = "특정 기사를 포함한 대화")
     @PostMapping("/news/{newsId}/talk")
-    public ApiResponse<ChatDtoRes.ChatTlakRes> specificNewsChat(@PathVariable Long newsId, @RequestBody ChatbotReq.ChatMessageRes chatbotReq) {
+    public ApiResponse<ChatDtoRes.ChatTlakRes> specificNewsChat(@PathVariable Long newsId, @RequestBody ChatbotReq.ChatMessageReq chatbotReq) {
         Long userId = jwtTokenProvider.getUserIdFromToken();
-        return ApiResponse.onSuccess(chatService.getMyChatSpecificNews(userId, newsId, chatbotReq.getMessage(), chatbotReq.getChatRoomId()));
+        return ApiResponse.onSuccess(chatService.getMyChatSpecificNews(userId, newsId, chatbotReq.getMessage()));
     }
 }

--- a/src/main/java/com/ohnew/ohnew/controller/UserController.java
+++ b/src/main/java/com/ohnew/ohnew/controller/UserController.java
@@ -5,10 +5,13 @@ import com.ohnew.ohnew.apiPayload.code.status.SuccessStatus;
 import com.ohnew.ohnew.common.security.JwtTokenProvider;
 import com.ohnew.ohnew.dto.req.TokenDtoReq;
 import com.ohnew.ohnew.dto.req.UserDtoReq;
+import com.ohnew.ohnew.dto.req.UserPreferenceDtoReq;
 import com.ohnew.ohnew.dto.res.KakaoUserInfoResponseDto;
 import com.ohnew.ohnew.dto.res.UserDtoRes;
+import com.ohnew.ohnew.dto.res.UserPreferenceDtoRes;
 import com.ohnew.ohnew.entity.User;
 import com.ohnew.ohnew.service.KakaoService;
+import com.ohnew.ohnew.service.UserPreferenceService;
 import com.ohnew.ohnew.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,6 +27,7 @@ public class UserController {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoService kakaoService;
+    private final UserPreferenceService userPreferenceService;
 
     @Operation(summary = "카카오로그인(앱)", description = "앱에서 '카카오 액세스 토큰'을 전달")
     @PostMapping("/kakao-login")
@@ -33,11 +37,6 @@ public class UserController {
         return ApiResponse.onSuccess(userService.kakaoLogin(httpRequest, httpResponse, user));
     }
 
-//    @Operation(summary = "이메일 로그인 API(테스트용)", description = "이메일로 JWT토큰 발급")
-//    @PostMapping("/login")
-//    public ApiResponse<UserDtoRes.UserLoginRes> login(@RequestBody @Valid UserDtoReq.LoginReq loginDto, HttpServletRequest request, HttpServletResponse response) {
-//        return ApiResponse.onSuccess(userService.login(request,response,loginDto));
-//    }
 
     @Operation(summary = "로그아웃(앱)", description = "액세스 토큰을 무효화하여 로그아웃")
     @PostMapping("/logout")
@@ -98,13 +97,18 @@ public class UserController {
 
         return ApiResponse.onSuccess(res);
     }
+    @Operation(summary = "내 뉴스 선호 조회", description = "선호 스타일/선호 태그/차단 태그")
+    @GetMapping("/preferences/news")
+    public ApiResponse<UserPreferenceDtoRes> getNewsPreference() {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        return ApiResponse.onSuccess(userPreferenceService.getPreference(userId));
+    }
 
-    //    @Operation(summary = "회원 기본 정보 조회 API", description = "사용자의 기본 정보를 조회합니다.")
-//    @GetMapping("/basic-info")
-//    public ApiResponse<UserDtoRes.userProfileRes> getUserBasicInfo() {
-//        Long userId = jwtTokenProvider.getUserIdFromToken();
-//        UserDtoRes.userProfileRes userBasicInfo = userService.getUserBasicInfo(userId);
-//        return ApiResponse.onSuccess(userBasicInfo);
-//    }
+    @Operation(summary = "내 뉴스 선호 저장", description = "선호 스타일 및 태그를 저장(덮어쓰기)")
+    @PutMapping("/preferences/news")
+    public ApiResponse<UserPreferenceDtoRes> saveNewsPreference(@RequestBody UserPreferenceDtoReq req) {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        return ApiResponse.onSuccess(userPreferenceService.savePreference(userId, req));
+    }
 
 }

--- a/src/main/java/com/ohnew/ohnew/converter/NewsConverter.java
+++ b/src/main/java/com/ohnew/ohnew/converter/NewsConverter.java
@@ -2,33 +2,34 @@ package com.ohnew.ohnew.converter;
 
 import com.ohnew.ohnew.dto.res.NewsDtoRes;
 import com.ohnew.ohnew.entity.News;
+import com.ohnew.ohnew.entity.NewsSummaryVariant;
 
 import java.util.ArrayList;
 
 public class NewsConverter {
 
-    public static NewsDtoRes.NewsSummaryRes toSummary(News n, boolean scrapped) {
+    public static NewsDtoRes.NewsSummaryRes toSummary(News n, NewsSummaryVariant v, boolean scrapped) {
         return NewsDtoRes.NewsSummaryRes.builder()
                 .newsId(n.getId())
-                .title(n.getTitle())
+                .title(v.getNewTitle())
                 .originalPublishedAt(n.getOriginalPublishedAt())
                 .tags(new ArrayList<>(n.getTags()))
                 .scrapped(scrapped)
                 .build();
     }
 
-    public static NewsDtoRes.NewsDetailRes toDetail(News n, boolean scrapped) {
+    public static NewsDtoRes.NewsDetailRes toDetail(News n, NewsSummaryVariant v, boolean scrapped) {
         return NewsDtoRes.NewsDetailRes.builder()
                 .newsId(n.getId())
-                .title(n.getTitle())
-                .summary(n.getSummary())
+                .title(v.getNewTitle())
+                .summary(v.getSummary())
                 .originalUrl(n.getOriginalUrl())
                 .originalPublishedAt(n.getOriginalPublishedAt())
                 .tags(new ArrayList<>(n.getTags()))
                 .recommendedQuestions(n.getRecommendedQuestions())
-                .scrapped(scrapped)
                 .quiz(n.getQuizQuestion())
                 .answer(n.getQuizAnswer())
+                .scrapped(scrapped)
                 .build();
     }
 }

--- a/src/main/java/com/ohnew/ohnew/dto/req/ChatbotReq.java
+++ b/src/main/java/com/ohnew/ohnew/dto/req/ChatbotReq.java
@@ -34,8 +34,7 @@ public class ChatbotReq {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatMessageRes{
+    public static class ChatMessageReq{
         private String message;
-        private Long chatRoomId;
     }
 }

--- a/src/main/java/com/ohnew/ohnew/dto/req/UserPreferenceDtoReq.java
+++ b/src/main/java/com/ohnew/ohnew/dto/req/UserPreferenceDtoReq.java
@@ -1,0 +1,14 @@
+package com.ohnew.ohnew.dto.req;
+
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class UserPreferenceDtoReq {
+    private NewsStyle preferredStyle;   // CONCISE | FRIENDLY | NEUTRAL
+    private Set<String> likedTags;      // 보고 싶은 태그
+    private Set<String> blockedTags;    // 보기 싫은 태그
+}
+

--- a/src/main/java/com/ohnew/ohnew/dto/res/NewsByPythonRes.java
+++ b/src/main/java/com/ohnew/ohnew/dto/res/NewsByPythonRes.java
@@ -1,5 +1,6 @@
 package com.ohnew.ohnew.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -34,13 +35,20 @@ public class NewsByPythonRes {
     @AllArgsConstructor
     public static class NewsData {
         private String articleId;
+        private List<Variant> variants; // 3개
+        private List<String> questions; // 기사당 1세트
+        private Quiz quiz;              // 기사당 1세트
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true) // 다른 필드가 와도 무시
+    public static class Variant {
+        private String newsStyle;
         private String newTitle;
         private String summary;
-        private List<String> questions;
-        private Quiz quiz;
-        private AiToken tokensUsed;
-        private String model;
-        private Long latencyMs;
+        private Epi epi;
     }
 
     @Data
@@ -54,10 +62,9 @@ public class NewsByPythonRes {
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class AiToken {
-        private Long input;
-        private Long output;
+    public static class Epi {
+        private String stimulationReduced;
+        private String reason;
     }
-
 
 }

--- a/src/main/java/com/ohnew/ohnew/dto/res/UserPreferenceDtoRes.java
+++ b/src/main/java/com/ohnew/ohnew/dto/res/UserPreferenceDtoRes.java
@@ -1,0 +1,15 @@
+package com.ohnew.ohnew.dto.res;
+
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+@Builder
+public class UserPreferenceDtoRes {
+    private NewsStyle preferredStyle;
+    private Set<String> likedTags;
+    private Set<String> blockedTags;
+}

--- a/src/main/java/com/ohnew/ohnew/entity/ChatMessage.java
+++ b/src/main/java/com/ohnew/ohnew/entity/ChatMessage.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ChatMessage extends BaseEntity {

--- a/src/main/java/com/ohnew/ohnew/entity/ChatRoom.java
+++ b/src/main/java/com/ohnew/ohnew/entity/ChatRoom.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ChatRoom extends BaseEntity {

--- a/src/main/java/com/ohnew/ohnew/entity/News.java
+++ b/src/main/java/com/ohnew/ohnew/entity/News.java
@@ -4,14 +4,13 @@ import com.ohnew.ohnew.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import javax.naming.Name;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class News extends BaseEntity {
@@ -20,15 +19,8 @@ public class News extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // AI가 생성한 기사 제목
-    private String title;
-
-    // AI가 요약한 기사 본문
-    @Column(columnDefinition = "TEXT")
-    private String summary;
-
     // 원본 기사 URL
-    @Column(unique = true)
+    @Column(unique = true,  nullable = false)
     private String originalUrl;
 
     // 원본 기사 생성(발행) 날짜
@@ -38,17 +30,47 @@ public class News extends BaseEntity {
     @ElementCollection
     @CollectionTable(name = "news_tags", joinColumns = @JoinColumn(name = "news_id"))
     @Column(name = "tag")
-    private Set<String> tags;
+    @Builder.Default
+    private Set<String> tags = new java.util.HashSet<>();
 
-    // AI가 생성한 추천 질문(최대 4개 예상) - 간단 리스트로 저장
+    // AI가 생성한 추천 질문
     @ElementCollection
     @CollectionTable(name = "news_recommended_questions", joinColumns = @JoinColumn(name = "news_id"))
     @Column(name = "question")
-    private List<String> recommendedQuestions;
+    @Builder.Default
+    private List<String> recommendedQuestions= new java.util.ArrayList<>();
 
     @Column(name = "quiz_question")
     private String quizQuestion;
 
     @Column(name = "quiz_answer")
-    private String quizAnswer;
+    private String quizAnswer; //YES,NO -> enum으로 바꿀 예정
+
+    // --- 도메인 메서드 ---
+    public void replaceQuestions(java.util.List<String> questions) {
+        this.recommendedQuestions.clear();
+        if (questions == null) return;
+
+        java.util.LinkedHashSet<String> normalized = questions.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+
+        this.recommendedQuestions.addAll(normalized.stream().limit(4).toList());
+    }
+
+    public void setQuiz(String question, String answer) {
+        String q = (question == null) ? null : question.trim();
+        String a = (answer == null) ? null : answer.trim();
+
+        // 빈문자면 null 처리 (DB nullable)
+        this.quizQuestion = (q == null || q.isEmpty()) ? null : q;
+        this.quizAnswer   = (a == null || a.isEmpty()) ? null : a;
+    }
+
+    public void clearQuiz() {
+        this.quizQuestion = null;
+        this.quizAnswer = null;
+    }
 }

--- a/src/main/java/com/ohnew/ohnew/entity/NewsSummaryVariant.java
+++ b/src/main/java/com/ohnew/ohnew/entity/NewsSummaryVariant.java
@@ -1,0 +1,50 @@
+package com.ohnew.ohnew.entity;
+
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import com.ohnew.ohnew.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "news_summary_variant",
+        uniqueConstraints = @UniqueConstraint(name="uk_news_style", columnNames = {"news_id","news_style"})
+        , indexes = @Index(name="idx_variant_news", columnList="news_id")
+)
+public class NewsSummaryVariant extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 부모 기사
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "news_style", nullable = false, length = 16)
+    private NewsStyle newsStyle;
+
+    private String newTitle;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    // 자극도
+    @Column(name = "epi_stimulation_reduced")
+    private String epiStimulationReduced;
+
+    @Column(name = "epi_reason")
+    private String epiReason;
+
+    public void updateFromLLM(String title, String sum, String stimReduced, String reason) {
+        this.newTitle = title;
+        this.summary = sum;
+        this.epiStimulationReduced = stimReduced;
+        this.epiReason = reason;
+    }
+}

--- a/src/main/java/com/ohnew/ohnew/entity/Scrap.java
+++ b/src/main/java/com/ohnew/ohnew/entity/Scrap.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Scrap extends BaseEntity {

--- a/src/main/java/com/ohnew/ohnew/entity/User.java
+++ b/src/main/java/com/ohnew/ohnew/entity/User.java
@@ -3,14 +3,11 @@ package com.ohnew.ohnew.entity;
 import com.ohnew.ohnew.entity.enums.Provider;
 import com.ohnew.ohnew.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class User extends BaseEntity {

--- a/src/main/java/com/ohnew/ohnew/entity/UserPreference.java
+++ b/src/main/java/com/ohnew/ohnew/entity/UserPreference.java
@@ -1,0 +1,75 @@
+package com.ohnew.ohnew.entity;
+
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import com.ohnew.ohnew.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_preference")
+public class UserPreference extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private NewsStyle preferredStyle = NewsStyle.NEUTRAL;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_preference_liked_tags", joinColumns = @JoinColumn(name = "preference_id"))
+    @Column(name = "tag")
+    private java.util.Set<String> likedTags = new java.util.HashSet<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_preference_blocked_tags", joinColumns = @JoinColumn(name = "preference_id"))
+    @Column(name = "tag")
+    private java.util.Set<String> blockedTags = new java.util.HashSet<>();
+
+    @Builder
+    private UserPreference(User user, NewsStyle preferredStyle, Set<String> likedTags, Set<String> blockedTags) {
+        this.user = java.util.Objects.requireNonNull(user);
+        if (preferredStyle != null) this.preferredStyle = preferredStyle;
+        if (likedTags != null) this.likedTags.addAll(likedTags);
+        if (blockedTags != null) this.blockedTags.addAll(blockedTags);
+    }
+
+    // 도메인 메서드
+    public void changeStyle(NewsStyle style) { if (style != null) this.preferredStyle = style; }
+
+    public void setLikedTags(Set<String> tags) {
+        this.likedTags.clear();
+        if (tags != null) this.likedTags.addAll(normalize(tags)); // 정규화
+    }
+    public void setBlockedTags(Set<String> tags) {
+        this.blockedTags.clear();
+        if (tags != null) this.blockedTags.addAll(normalize(tags)); // 정규화
+    }
+    public boolean addLikedTag(String tag) {
+        String t = tag == null ? null : tag.trim();
+        return (t != null && !t.isEmpty()) && this.likedTags.add(t);
+    }
+    public boolean removeLikedTag(String tag) { return this.likedTags.remove(tag); }
+    public boolean addBlockedTag(String tag) {
+        String t = tag == null ? null : tag.trim();
+        return (t != null && !t.isEmpty()) && this.blockedTags.add(t);
+    }
+    public boolean removeBlockedTag(String tag) { return this.blockedTags.remove(tag); }
+
+    // 정규화 유틸
+    private static java.util.Set<String> normalize(java.util.Set<String> src) {
+        return src.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+    }
+}

--- a/src/main/java/com/ohnew/ohnew/entity/enums/NewsStyle.java
+++ b/src/main/java/com/ohnew/ohnew/entity/enums/NewsStyle.java
@@ -1,0 +1,7 @@
+package com.ohnew.ohnew.entity.enums;
+
+public enum NewsStyle {
+    CONCISE, //간결함
+    FRIENDLY, //친근함
+    NEUTRAL //중립
+}

--- a/src/main/java/com/ohnew/ohnew/repository/NewsSummaryVariantRepository.java
+++ b/src/main/java/com/ohnew/ohnew/repository/NewsSummaryVariantRepository.java
@@ -1,0 +1,13 @@
+package com.ohnew.ohnew.repository;
+
+import com.ohnew.ohnew.entity.NewsSummaryVariant;
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NewsSummaryVariantRepository extends JpaRepository<NewsSummaryVariant, Long> {
+    Optional<NewsSummaryVariant> findByNewsIdAndNewsStyle(Long newsId, NewsStyle style);
+    List<NewsSummaryVariant> findAllByNewsId(Long newsId);
+}

--- a/src/main/java/com/ohnew/ohnew/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/ohnew/ohnew/repository/UserPreferenceRepository.java
@@ -1,0 +1,10 @@
+package com.ohnew.ohnew.repository;
+
+import com.ohnew.ohnew.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+    Optional<UserPreference> findByUserId(Long userId);
+}

--- a/src/main/java/com/ohnew/ohnew/service/ChatService.java
+++ b/src/main/java/com/ohnew/ohnew/service/ChatService.java
@@ -6,5 +6,5 @@ public interface ChatService {
     ChatDtoRes.EnterChatRoomRes enterChatRoom(Long userId, Long newsId);
     ChatDtoRes.ChatMessagesRes getMyChatMessagesForNews(Long userId, Long newsId);
     ChatDtoRes.ChattedNewsListRes getMyChattedNewsList(Long userId);
-    ChatDtoRes.ChatTlakRes getMyChatSpecificNews(Long userId, Long newsId, String userMessage, Long chatRoomId);
+    ChatDtoRes.ChatTlakRes getMyChatSpecificNews(Long userId, Long newsId, String userMessage);
 }

--- a/src/main/java/com/ohnew/ohnew/service/NewsServiceImpl.java
+++ b/src/main/java/com/ohnew/ohnew/service/NewsServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -121,12 +122,12 @@ public class NewsServiceImpl implements NewsService {
 
         // 선호 태그 포함 뉴스 우선 정렬
         var sorted = filtered.stream()
-                .sorted((a,b) -> {
-                    boolean aLiked = hasAny(a.getTags(), liked);
-                    boolean bLiked = hasAny(b.getTags(), liked);
-                    if (aLiked == bLiked) return 0;
-                    return aLiked ? -1 : 1; // 선호 포함 뉴스 먼저
-                })
+                .sorted(
+                        Comparator
+                                .comparing((News n) -> hasAny(n.getTags(), liked))
+                                .reversed() // 선호 태그 포함 = true 먼저
+                                .thenComparing(News::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                )
                 .limit(20) // 20개 제한
                 .toList();
 

--- a/src/main/java/com/ohnew/ohnew/service/NewsServiceImpl.java
+++ b/src/main/java/com/ohnew/ohnew/service/NewsServiceImpl.java
@@ -5,12 +5,14 @@ import com.ohnew.ohnew.apiPayload.code.status.ErrorStatus;
 import com.ohnew.ohnew.converter.NewsConverter;
 import com.ohnew.ohnew.dto.res.NewsDtoRes;
 import com.ohnew.ohnew.entity.*;
+import com.ohnew.ohnew.entity.enums.NewsStyle;
 import com.ohnew.ohnew.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +22,11 @@ public class NewsServiceImpl implements NewsService {
     private final NewsRepository newsRepository;
     private final ScrapRepository scrapRepository;
     private final UserRepository userRepository;
+    private final NewsSummaryVariantRepository variantRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
 
+    private static final NewsStyle DEFAULT_STYLE =
+            NewsStyle.NEUTRAL;
 
     private News getNewsOrThrow(Long newsId) {
         return newsRepository.findById(newsId)
@@ -32,11 +38,36 @@ public class NewsServiceImpl implements NewsService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
+    private NewsStyle resolveUserStyle(Long userId) {
+        // 사용자 선호 스타일 조회 (없으면 기본)
+        return userPreferenceRepository.findByUserId(userId)
+                .map(UserPreference::getPreferredStyle)
+                .orElse(DEFAULT_STYLE);
+    }
+
+    private boolean hasAny(Set<String> tags, Set<String> target) {
+        if (tags == null || target == null) return false;
+        for (String t : tags) {
+            if (target.contains(t)) return true;
+        }
+        return false;
+    }
+
     @Override
     public NewsDtoRes.NewsDetailRes getNewsDetail(Long userId, Long newsId) {
+        User user = getUserOrThrow(userId);
         News news = getNewsOrThrow(newsId);
         boolean scrapped = scrapRepository.existsByUserIdAndNewsId(userId, newsId);
-        return NewsConverter.toDetail(news, scrapped);
+
+        var style = resolveUserStyle(userId); // 사용자 선호 스타일
+
+        // 선호 스타일 변형이 없으면 NEUTRAL로 폴백
+        var variant = variantRepository.findByNewsIdAndNewsStyle(newsId, style)
+                .orElseGet(() -> variantRepository.findByNewsIdAndNewsStyle(newsId, DEFAULT_STYLE)
+                        .orElseThrow(() -> new GeneralException(
+                                ErrorStatus.VARIANT_NOT_FOUND)));
+
+        return NewsConverter.toDetail(news, variant, scrapped);
     }
 
     @Override
@@ -60,21 +91,54 @@ public class NewsServiceImpl implements NewsService {
 
     @Override
     public List<NewsDtoRes.NewsSummaryRes> getMyScrapList(Long userId) {
+        var style = resolveUserStyle(userId); // 사용자 선호 스타일
         return scrapRepository.findByUserId(userId).stream()
-                .map(s -> NewsConverter.toSummary(s.getNews(), true))
+                .map(s -> {
+                    var news = s.getNews();
+                    var variant = variantRepository.findByNewsIdAndNewsStyle(news.getId(), style)
+                            .orElseGet(() -> variantRepository.findByNewsIdAndNewsStyle(news.getId(), DEFAULT_STYLE)
+                                    .orElseThrow(() -> new GeneralException(
+                                            ErrorStatus.VARIANT_NOT_FOUND)));
+                    return NewsConverter.toSummary(news, variant, true); // variant 넘김
+                })
                 .toList();
     }
 
     @Override
     public List<NewsDtoRes.NewsDetailRes> getTodayNews(Long userId) {
-        // 1. 사용자 확인 (없으면 예외)
         getUserOrThrow(userId);
 
-        // 2. 오늘 날짜 기준으로 뉴스 조회
-        return newsRepository.findAllByOrderByCreatedAtDesc().stream()
+        // 사용자 선호 가져오기 (스타일/선호태그/차단태그)
+        var pref = userPreferenceRepository.findByUserId(userId).orElse(null);
+        var style = pref != null ? pref.getPreferredStyle() : DEFAULT_STYLE;
+        var liked = pref != null ? pref.getLikedTags() : java.util.Collections.<String>emptySet();
+        var blocked = pref != null ? pref.getBlockedTags() : java.util.Collections.<String>emptySet();
+
+        // 차단 태그 포함 뉴스 배제
+        var filtered = newsRepository.findAllByOrderByCreatedAtDesc().stream()
+                .filter(n -> !hasAny(n.getTags(), blocked)) // 차단 태그 필터
+                .toList();
+
+        // 선호 태그 포함 뉴스 우선 정렬
+        var sorted = filtered.stream()
+                .sorted((a,b) -> {
+                    boolean aLiked = hasAny(a.getTags(), liked);
+                    boolean bLiked = hasAny(b.getTags(), liked);
+                    if (aLiked == bLiked) return 0;
+                    return aLiked ? -1 : 1; // 선호 포함 뉴스 먼저
+                })
+                .limit(20) // 20개 제한
+                .toList();
+
+        // 각 뉴스에 대해 선호 스타일 (없으면 NEUTRAL) 조회 후 변환
+        return sorted.stream()
                 .map(news -> {
                     boolean scrapped = scrapRepository.existsByUserIdAndNewsId(userId, news.getId());
-                    return NewsConverter.toDetail(news, scrapped);
+                    var variant = variantRepository.findByNewsIdAndNewsStyle(news.getId(), style)
+                            .orElseGet(() -> variantRepository.findByNewsIdAndNewsStyle(news.getId(), DEFAULT_STYLE)
+                                    .orElseThrow(() -> new GeneralException(
+                                            ErrorStatus.VARIANT_NOT_FOUND)));
+                    return NewsConverter.toDetail(news, variant, scrapped);
                 })
                 .toList();
     }

--- a/src/main/java/com/ohnew/ohnew/service/NewsVariantService.java
+++ b/src/main/java/com/ohnew/ohnew/service/NewsVariantService.java
@@ -1,0 +1,44 @@
+package com.ohnew.ohnew.service;
+
+import com.ohnew.ohnew.apiPayload.code.exception.GeneralException;
+import com.ohnew.ohnew.apiPayload.code.status.ErrorStatus;
+import com.ohnew.ohnew.entity.News;
+import com.ohnew.ohnew.entity.NewsSummaryVariant;
+import com.ohnew.ohnew.entity.enums.NewsStyle;
+import com.ohnew.ohnew.repository.NewsRepository;
+import com.ohnew.ohnew.repository.NewsSummaryVariantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NewsVariantService {
+
+    private final NewsRepository newsRepository;
+    private final NewsSummaryVariantRepository variantRepository;
+
+    @Transactional
+    public void upsertVariant(Long newsId,
+                              NewsStyle style,
+                              String newTitle,
+                              String summary,
+                              String epiStimulationReduced,
+                              String epiReason) {
+
+        News news = newsRepository.findById(newsId)
+                .orElseThrow(() -> new GeneralException(
+                        ErrorStatus.RESOURCE_NOT_FOUND));
+
+        NewsSummaryVariant entity = variantRepository.findByNewsIdAndNewsStyle(newsId, style)
+                .orElseGet(() -> NewsSummaryVariant.builder()
+                        .news(news)
+                        .newsStyle(style)
+                        .build());
+
+        entity.updateFromLLM(newTitle, summary, epiStimulationReduced, epiReason);
+
+        // 더티체킹으로도 flush되지만 upsert 명시를 위함....
+        variantRepository.save(entity);
+    }
+}

--- a/src/main/java/com/ohnew/ohnew/service/UserPreferenceService.java
+++ b/src/main/java/com/ohnew/ohnew/service/UserPreferenceService.java
@@ -1,0 +1,72 @@
+package com.ohnew.ohnew.service;
+
+import com.ohnew.ohnew.apiPayload.code.exception.GeneralException;
+import com.ohnew.ohnew.apiPayload.code.status.ErrorStatus;
+import com.ohnew.ohnew.dto.req.UserPreferenceDtoReq;
+import com.ohnew.ohnew.dto.res.UserPreferenceDtoRes;
+import com.ohnew.ohnew.entity.User;
+import com.ohnew.ohnew.entity.UserPreference;
+import com.ohnew.ohnew.repository.UserPreferenceRepository;
+import com.ohnew.ohnew.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceService {
+
+    private final UserRepository userRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(
+                        ErrorStatus.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public UserPreferenceDtoRes getPreference(Long userId) {
+        var pref = userPreferenceRepository.findByUserId(userId).orElse(null);
+        if (pref == null) {
+            // 기본값: NEUTRAL, 공백 태그
+            return UserPreferenceDtoRes.builder()
+                    .preferredStyle(com.ohnew.ohnew.entity.enums.NewsStyle.NEUTRAL)
+                    .likedTags(java.util.Collections.emptySet())
+                    .blockedTags(java.util.Collections.emptySet())
+                    .build();
+        }
+        return UserPreferenceDtoRes.builder()
+                .preferredStyle(pref.getPreferredStyle())
+                .likedTags(pref.getLikedTags())
+                .blockedTags(pref.getBlockedTags())
+                .build();
+    }
+
+    @Transactional
+    public UserPreferenceDtoRes savePreference(Long userId, UserPreferenceDtoReq req) {
+        var user = getUserOrThrow(userId);
+        var entity = userPreferenceRepository.findByUserId(userId)
+                .orElseGet(() -> UserPreference.builder()
+                        .user(user)
+                        .preferredStyle(com.ohnew.ohnew.entity.enums.NewsStyle.NEUTRAL)
+                        .build());
+
+        if (req.getPreferredStyle() != null) {
+            entity.changeStyle(req.getPreferredStyle());
+        }
+        if (req.getLikedTags() != null) {
+            entity.setLikedTags(req.getLikedTags());
+        }
+        if (req.getBlockedTags() != null) {
+            entity.setBlockedTags(req.getBlockedTags());
+        }// null이 온 경우 기존값 유지. "비우기"를 원한다면 빈 Set을 보내야함
+
+        var saved = userPreferenceRepository.save(entity);    // JPA 더티체킹으로도 저장되지만 upsert명시용....
+        return UserPreferenceDtoRes.builder()
+                .preferredStyle(saved.getPreferredStyle())
+                .likedTags(saved.getLikedTags())
+                .blockedTags(saved.getBlockedTags())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 이슈 번호
[#19]
## ✨ PR 요약
<!--변경 포인트-->
- 3가지 스타일 요약(Variant) 저장/조회 구조 도입

- 부모 News에 공통 Q&A(추천질문/퀴즈) 저장

- Python /v1/rewrite-batch3 연동 및 트랜잭션/도메인 메서드 적용

- 채팅에서 chatRoomId 입력 제거(서버에서 find-or-create)
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 엔티티/스키마

NewsSummaryVariant 신설: (news_id, news_style) 유니크, newTitle/summary/epi* 보관

News에서 요약/제목 제거, recommendedQuestions/quizQuestion/quizAnswer 유지

도메인 메서드 추가: replaceQuestions(...), setQuiz(...)/clearQuiz()

- 수집/저장

RssService: Python /v1/rewrite-batch3 호출 → 스타일별 Variant upsert

부모 News에는 Q&A 1회만 저장(도메인 메서드 사용)

스케줄러 메서드 public void + @Transactional로 더티체킹 보장

- 조회/채팅

NewsConverter.toDetail(News, NewsSummaryVariant)로 변경

오늘의 뉴스 조회 api 사용자 선호 스타일/태그 반영한 정렬

채팅: (userId, newsId) 기준 방 자동 생성, Variant 요약으로 대화 컨텍스트 구성

---
