### PR TITLE
:hammer: REF [#19] 뉴스 요약 webClient 호출 타임 아웃 시간 설정.

### DIFF
--- a/src/main/java/com/ohnew/ohnew/service/RssServiceImpl.java
+++ b/src/main/java/com/ohnew/ohnew/service/RssServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.net.URL;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -122,10 +123,11 @@ public class RssServiceImpl {
     private void callPythonApi(NewsByMultiRssRes multiRes) {
         try {
             NewsByPythonRes pythonRes = webClient.post()
-                    .uri("http://localhost:8000/v1/rewrite-batch3") // ★ 교체
+                    .uri("http://localhost:8000/v1/rewrite-batch3")
                     .bodyValue(multiRes)
                     .retrieve()
                     .bodyToMono(NewsByPythonRes.class)
+                    .timeout(Duration.ofMinutes(10))// 10분.
                     .block();
 
             if (pythonRes != null && pythonRes.getResults() != null) {


### PR DESCRIPTION
## 🔍 이슈 번호
 [#19] 
## ✨ PR 요약
<!--변경 포인트-->
- 뉴스 요약 webClient 호출 타임 아웃 시간 설정
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 타임아웃시간 10분으로 설정 (기사 업데이트 10개기준)
- 파이썬에서 청크 단위로 LLM 요청을 보내고 몇초 후에 또 요청으로 보내고 있음

---
